### PR TITLE
Use correct signer address when validating transfer

### DIFF
--- a/src/signature.ts
+++ b/src/signature.ts
@@ -20,6 +20,7 @@ const domain = {
   name: 'Farcaster name verification',
   version: '1',
   chainId: 1,
+  // TODO: When changing, remember to also update on the backend!
   verifyingContract: '0xe3be01d99baa8db9905b33a3ca391238234b79d1', // name registry contract, will be the farcaster ENS CCIP contract later
 };
 const types = {

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -51,7 +51,7 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
     throw new ValidationError('UNAUTHORIZED');
   }
 
-  if (!verifySignature(req.username, req.timestamp, req.owner, req.userSignature, signer.address)) {
+  if (!verifySignature(req.username, req.timestamp, req.owner, req.userSignature, verifierAddress)) {
     throw new ValidationError('INVALID_SIGNATURE');
   }
 


### PR DESCRIPTION
This ensures both the fname-registry and Warpcast backend can both make admin changes.
