### PR TITLE
Fix Datadog initialization

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -1,5 +1,7 @@
-import { tracer } from 'dd-trace';
+import pkg from 'dd-trace';
 import { ENVIRONMENT, SERVICE } from './env.js';
+
+const { tracer } = pkg;
 
 tracer.init({
   env: ENVIRONMENT,


### PR DESCRIPTION
In DD 4 this changed. Update to get this to work with ESM modules.
