### PR TITLE
fix: ensure timestamps cannot be too old

### DIFF
--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -138,6 +138,11 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
     throw new ValidationError('INVALID_TIMESTAMP');
   }
 
+  if (req.timestamp < currentTimestamp() - TIMESTAMP_TOLERANCE) {
+    log.error(`Timestamp ${req.timestamp} was < ${TIMESTAMP_TOLERANCE}`);
+    throw new ValidationError('INVALID_TIMESTAMP');
+  }
+
   if (existingTransfer && existingTransfer.timestamp > req.timestamp) {
     log.error(`Timestamp ${req.timestamp} < previous transfer timestamp of ${existingTransfer.timestamp}`);
     throw new ValidationError('INVALID_TIMESTAMP');

--- a/tests/transfers.test.ts
+++ b/tests/transfers.test.ts
@@ -89,6 +89,15 @@ describe('transfers', () => {
       await expect(
         createTestTransfer(db, { username: 'test123', from: 2, to: 10, timestamp: currentTimestamp() + 100 })
       ).rejects.toThrow('INVALID_TIMESTAMP');
+
+      // Timestamp cannot be too far in the past
+      await expect(
+        createTestTransfer(db, { username: 'newusername', from: 0, to: 15, timestamp: currentTimestamp() - 100 })
+      ).rejects.toThrow('INVALID_TIMESTAMP');
+
+      await expect(createTestTransfer(db, { username: 'newusername', from: 0, to: 15, timestamp: 0 })).rejects.toThrow(
+        'INVALID_TIMESTAMP'
+      );
     });
 
     test('fails for an invalid signature', async () => {


### PR DESCRIPTION
We were not checking that timestamps could not be too far into the past. This would allow someone to register an fname with timestamp 0 (or timestamp older than the `FARCASTER_EPOCH`).