### PR TITLE
fix: Handle zero padded names

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -56,7 +56,7 @@ app.get('/transfers', async (req, res) => {
     filterOpts.fromId = parseInt(req.query.fromId.toString());
   }
   if (req.query.name) {
-    filterOpts.name = req.query.name.toString();
+    filterOpts.name = req.query.name.toString().replace(/\0/g, '');
   }
   if (req.query.from_ts) {
     filterOpts.fromTs = parseInt(req.query.from_ts.toString());

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -78,6 +78,14 @@ describe('app', () => {
       expect(response.body.transfers).toHaveLength(1);
       expect(response.body.transfers[0]).toMatchObject({ username: 'test3', from: 3, to: 0, timestamp: now + 2 });
     });
+
+    test('does not fail for zero padded names', async () => {
+      const zeroPaddedName = Buffer.concat([Buffer.from('test2'), Buffer.alloc(3)]).toString('utf-8');
+      const response = await request(app).get(`/transfers?name=${zeroPaddedName}`);
+      expect(response.status).toBe(200);
+      expect(response.body.transfers).toHaveLength(1);
+      expect(response.body.transfers[0]).toMatchObject({ username: 'test2' });
+    });
   });
 
   describe('get current transfer', () => {


### PR DESCRIPTION
Handle zero padded name requests (older hubs do not strip zero padded names in the SyncTrie of newer hubs)