### PR TITLE
Update kysely-postgres-js integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "ethers": "^6.10.0",
     "express": "^4.18.2",
     "kysely": "^0.26.3",
-    "kysely-postgres-js": "^1.1.1",
+    "kysely-postgres-js": "^2.0.0",
     "neverthrow": "^6.1.0",
     "pino": "^8.16.1",
     "pino-pretty": "^10.3.1",
-    "postgres": "^3.4.1"
+    "postgres": "^3.4.3"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",

--- a/src/db.ts
+++ b/src/db.ts
@@ -33,21 +33,19 @@ export interface TransfersTable {
 export const getDbClient = () => {
   return new Kysely<Database>({
     dialect: new PostgresJSDialect({
-      connectionString: POSTGRES_URL,
-      options: {
+      postgres: postgres(POSTGRES_URL, {
         max: 10,
         types: {
           // BigInts will not exceed Number.MAX_SAFE_INTEGER for our use case.
           // Return as JavaScript's `number` type so it's easier to work with.
           bigint: {
             to: 20,
-            from: 20,
+            from: [20],
             parse: (x: any) => Number(x),
             serialize: (x: any) => x.toString(),
           },
         },
-      },
-      postgres,
+      }),
     }),
     plugins: [new CamelCasePlugin()],
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,10 +3796,10 @@ koalas@^1.0.2:
   resolved "https://registry.yarnpkg.com/koalas/-/koalas-1.0.2.tgz#318433f074235db78fae5661a02a8ca53ee295cd"
   integrity sha512-RYhBbYaTTTHId3l6fnMZc3eGQNW6FVCqMG6AMwA5I1Mafr6AflaXeoi6x3xQuATRotGYRLk6+1ELZH4dstFNOA==
 
-kysely-postgres-js@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/kysely-postgres-js/-/kysely-postgres-js-1.1.1.tgz#d53a738403632f03d3a00c115af01b62a5f8c9c1"
-  integrity sha512-4liHLEA1TfdGVixiW2wM4UFqv0r+F06pxpFng7xSdyl4p6lUp0099W+jotq4inovneTbVDBaFKwn+uOiORXKGQ==
+kysely-postgres-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/kysely-postgres-js/-/kysely-postgres-js-2.0.0.tgz#f2e79f2e14c2c3065052722bdc89014691080ceb"
+  integrity sha512-R1tWx6/x3tSatWvsmbHJxpBZYhNNxcnMw52QzZaHKg7ZOWtHib4iZyEaw4gb2hNKVctWQ3jfMxZT/ZaEMK6kBQ==
 
 kysely@^0.26.3:
   version "0.26.3"
@@ -4359,10 +4359,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-postgres@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/postgres/-/postgres-3.4.1.tgz#f1446241cd6d6ce158b5104e62b39eea02b2b9ad"
-  integrity sha512-Wasjv6WEzrZXbwKByR2RGD7MBfj7VBqco3hYWz8ifzSAp6tb2L6MlmcKFzkmgV1jT7/vKlcSa+lxXZeTdeVMzQ==
+postgres@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/postgres/-/postgres-3.4.3.tgz#52a0712cd6c2dae5e9f8c35b5c7b33434caa66ed"
+  integrity sha512-iHJn4+M9vbTdHSdDzNkC0crHq+1CUdFhx+YqCE+SqWxPjm+Zu63jq7yZborOBF64c8pc58O5uMudyL1FQcHacA==
 
 pprof-format@^2.0.7:
   version "2.0.7"


### PR DESCRIPTION
This allows us to use the connection management supported directly by Postgres.js.
