### PR TITLE
Replace deprecated `cmpr` with `eb` in Kysely queries

### DIFF
--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -192,8 +192,8 @@ export async function getCurrentUsername(fid: number, db: Kysely<Database>) {
   const transfer = await db
     .selectFrom('transfers')
     .select(['username', 'from', 'to'])
-    .where(({ or, cmpr }) => {
-      return or([cmpr('from', '=', fid), cmpr('to', '=', fid)]);
+    .where(({ or, eb }) => {
+      return or([eb('from', '=', fid), eb('to', '=', fid)]);
     })
     .orderBy('timestamp', 'desc')
     .limit(1)


### PR DESCRIPTION
This allows us to upgrade Kysely in future, since `cmpr` is deprecated.
