### PR TITLE
fix: increase timestamp tolerance to handle job processing lag

### DIFF
--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -9,8 +9,8 @@ import { IdRegistry } from './abi/index.js';
 import { toNumber } from 'ethers';
 
 const PAGE_SIZE = 100;
-const TIMESTAMP_TOLERANCE = 60; // 1 minute
-const NAME_CHANGE_DELAY = 28 * 24 * 60 * 60; // 28 days in seconds
+export const TIMESTAMP_TOLERANCE = 5 * 60; // 5 minute
+export const NAME_CHANGE_DELAY = 28 * 24 * 60 * 60; // 28 days in seconds
 
 type TransferRequest = {
   timestamp: number;

--- a/tests/transfers.test.ts
+++ b/tests/transfers.test.ts
@@ -3,7 +3,7 @@
 import { getDbClient, migrateToLatest } from '../src/db.js';
 import { log } from '../src/log.js';
 import { sql } from 'kysely';
-import { getCurrentUsername, getLatestTransfer } from '../src/transfers.js';
+import { getCurrentUsername, getLatestTransfer, TIMESTAMP_TOLERANCE } from '../src/transfers.js';
 import { currentTimestamp } from '../src/util.js';
 import { createTestTransfer } from './utils.js';
 import { generateSignature, signer, signerAddress, signerFid } from '../src/signature.js';
@@ -87,12 +87,22 @@ describe('transfers', () => {
 
       // Timestamp cannot be too far in the future
       await expect(
-        createTestTransfer(db, { username: 'test123', from: 2, to: 10, timestamp: currentTimestamp() + 100 })
+        createTestTransfer(db, {
+          username: 'test123',
+          from: 2,
+          to: 10,
+          timestamp: currentTimestamp() + (TIMESTAMP_TOLERANCE + 10),
+        })
       ).rejects.toThrow('INVALID_TIMESTAMP');
 
       // Timestamp cannot be too far in the past
       await expect(
-        createTestTransfer(db, { username: 'newusername', from: 0, to: 15, timestamp: currentTimestamp() - 100 })
+        createTestTransfer(db, {
+          username: 'newusername',
+          from: 0,
+          to: 15,
+          timestamp: currentTimestamp() - (TIMESTAMP_TOLERANCE + 10),
+        })
       ).rejects.toThrow('INVALID_TIMESTAMP');
 
       await expect(createTestTransfer(db, { username: 'newusername', from: 0, to: 15, timestamp: 0 })).rejects.toThrow(


### PR DESCRIPTION
Some fname transfers are failing because we're not able to make the request before it's considered expired.