### PR TITLE
fix: Increase tolerance to 10 mins

### DIFF
--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -9,7 +9,7 @@ import { IdRegistry } from './abi/index.js';
 import { toNumber } from 'ethers';
 
 const PAGE_SIZE = 100;
-export const TIMESTAMP_TOLERANCE = 5 * 60; // 5 minute
+export const TIMESTAMP_TOLERANCE = 10 * 60; // 5 minute
 export const NAME_CHANGE_DELAY = 28 * 24 * 60 * 60; // 28 days in seconds
 
 type TransferRequest = {


### PR DESCRIPTION
Some clients seem to be sending up timestamps from the future. Increase tolerance for now.