### PR TITLE
Allocate full CPU to fname-registry

### DIFF
--- a/.aws/fname-registry-api.json
+++ b/.aws/fname-registry-api.json
@@ -115,8 +115,8 @@
       ]
     }
   ],
-  "cpu": "0.5 vCPU",
-  "memory": "1024",
+  "cpu": "1 vCPU",
+  "memory": "2048",
   "runtimePlatform": {
     "operatingSystemFamily": "LINUX",
     "cpuArchitecture": "ARM64"


### PR DESCRIPTION
The increase in number of requests is starting to result in slow responses. Increase allocated compute.
