### PR TITLE
Increase max size for DB connection pool

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -34,7 +34,7 @@ export const getDbClient = () => {
   return new Kysely<Database>({
     dialect: new PostgresJSDialect({
       postgres: postgres(POSTGRES_URL, {
-        max: 10,
+        max: 32,
         types: {
           // BigInts will not exceed Number.MAX_SAFE_INTEGER for our use case.
           // Return as JavaScript's `number` type so it's easier to work with.


### PR DESCRIPTION
We're seeing some performance data that's a bit odd, suggesting we might be stuck waiting for connections to be available. Try adding more, since most of our requests are simply proxying to the database.
