### PR TITLE
Double CPU+memory allocated to fname-registry

### DIFF
--- a/.aws/fname-registry-api.json
+++ b/.aws/fname-registry-api.json
@@ -119,8 +119,8 @@
       ]
     }
   ],
-  "cpu": "1 vCPU",
-  "memory": "2048",
+  "cpu": "2 vCPU",
+  "memory": "4096",
   "runtimePlatform": {
     "operatingSystemFamily": "LINUX",
     "cpuArchitecture": "ARM64"


### PR DESCRIPTION
We're still seeing Postgres waiting on the client (i.e. the fname-registry server) so let's see if we're blocked on CPU capacity.
