### PR TITLE
feat: update verifySignature to use viem client

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "neverthrow": "^7.0.1",
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",
-    "postgres": "^3.4.4"
+    "postgres": "^3.4.4",
+    "viem": "^2.17.3"
   },
   "devDependencies": {
     "@typechain/ethers-v6": "^0.5.1",

--- a/src/env.ts
+++ b/src/env.ts
@@ -17,7 +17,7 @@ if (WARPCAST_ADDRESS === '') {
 
 // Address of the ENS CCIP verifier contract
 export const CCIP_ADDRESS = process.env['CCIP_ADDRESS'] || '';
-if (WARPCAST_ADDRESS === '') {
+if (CCIP_ADDRESS === '') {
   throw new Error('CCIP_ADDRESS missing from .env');
 }
 

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -1,8 +1,8 @@
 import { ethers } from 'ethers';
-import { CCIP_ADDRESS, WARPCAST_ADDRESS } from './env.js';
 import * as process from 'process';
-import { createPublicClient, http } from 'viem';
-import { mainnet } from 'viem/chains';
+import { createPublicClient, fallback, http } from 'viem';
+import { optimism } from 'viem/chains';
+import { CCIP_ADDRESS, OP_ALCHEMY_SECRET, WARPCAST_ADDRESS } from './env.js';
 
 export const signer = ethers.Wallet.fromPhrase(
   process.env.MNEMONIC || 'test test test test test test test test test test test junk'
@@ -71,9 +71,10 @@ export async function verifySignature(
     owner: owner,
   };
 
+  const rpcUrl = `https://opt-mainnet.g.alchemy.com/v2/${OP_ALCHEMY_SECRET}`;
   const client = createPublicClient({
-    chain: mainnet,
-    transport: http(),
+    chain: optimism,
+    transport: fallback([http(rpcUrl), http()]),
   });
 
   const verifyResult = await client.verifyTypedData({

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -1,6 +1,8 @@
 import { ethers } from 'ethers';
 import { CCIP_ADDRESS, WARPCAST_ADDRESS } from './env.js';
 import * as process from 'process';
+import { createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
 
 export const signer = ethers.Wallet.fromPhrase(
   process.env.MNEMONIC || 'test test test test test test test test test test test junk'
@@ -23,7 +25,7 @@ const hub_domain = {
   chainId: 1,
   // TODO: When changing, remember to also update on the backend!
   verifyingContract: '0xe3be01d99baa8db9905b33a3ca391238234b79d1', // name registry contract, will be the farcaster ENS CCIP contract later
-};
+} as const;
 const ccip_domain = {
   name: 'Farcaster name verification',
   version: '1',
@@ -56,7 +58,7 @@ export async function generateCCIPSignature(userName: string, timestamp: number,
   return Buffer.from((await signer.signTypedData(ccip_domain, types, userNameProof)).replace(/^0x/, ''), 'hex');
 }
 
-export function verifySignature(
+export async function verifySignature(
   userName: string,
   timestamp: number,
   owner: string,
@@ -68,8 +70,22 @@ export function verifySignature(
     timestamp,
     owner: owner,
   };
-  const signer = ethers.verifyTypedData(hub_domain, types, userNameProof, signature);
-  return signer.toLowerCase() === signerAddress.toLowerCase();
+
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http(),
+  });
+
+  const verifyResult = await client.verifyTypedData({
+    domain: hub_domain,
+    types: types,
+    message: userNameProof,
+    primaryType: 'UserNameProof',
+    signature: signature as `0x${string}`,
+    address: signerAddress as `0x${string}`,
+  });
+
+  return verifyResult;
 }
 
 export function verifyCCIPSignature(

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -109,7 +109,15 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
     throw new ValidationError('USERNAME_RESERVED');
   }
 
-  if (!verifySignature(req.username, req.timestamp, req.owner, req.userSignature, verifierAddress)) {
+  const verifySignatureResult = await verifySignature(
+    req.username,
+    req.timestamp,
+    req.owner,
+    req.userSignature,
+    verifierAddress
+  );
+
+  if (!verifySignatureResult) {
     log.error(`Invalid signature for req ${JSON.stringify(req)}`);
     throw new ValidationError('INVALID_SIGNATURE');
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -146,12 +146,12 @@ describe('app', () => {
         timestamp: now,
         owner: anotherSigner.address.toLowerCase(),
       });
-      expect(verifySignature('test4', now, anotherSigner.address, transferRes.user_signature, signer.address)).toBe(
-        true
-      );
-      expect(verifySignature('test4', now, anotherSigner.address, transferRes.server_signature, signer.address)).toBe(
-        true
-      );
+      expect(
+        await verifySignature('test4', now, anotherSigner.address, transferRes.user_signature, signer.address)
+      ).toBe(true);
+      expect(
+        await verifySignature('test4', now, anotherSigner.address, transferRes.server_signature, signer.address)
+      ).toBe(true);
     });
 
     test('registering the same name to the same owner and fid twice should not fail', async () => {
@@ -241,7 +241,7 @@ describe('app', () => {
       expect(username).toBe('test1');
       expect(verifyCCIPSignature(username, timestamp, owner, signature, signer.address)).toBe(true);
       // CCIP domain is different from hub domain
-      expect(verifySignature(username, timestamp, owner, signature, signer.address)).toBe(false);
+      expect(await verifySignature(username, timestamp, owner, signature, signer.address)).toBe(false);
     });
 
     it('should return an empty signature for a ccip lookup of an unregistered name', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,6 +1295,14 @@
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
 
+"@scure/bip39@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
+  integrity sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==
+  dependencies:
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1626,6 +1634,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
+abitype@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.5.tgz#29d0daa3eea867ca90f7e4123144c1d1270774b6"
+  integrity sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==
 
 abitype@1.0.5:
   version "1.0.5"
@@ -3152,6 +3165,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isows@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.4.tgz#810cd0d90cc4995c26395d2aa4cfa4037ebdf061"
+  integrity sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==
 
 isows@1.0.4:
   version "1.0.4"
@@ -4892,6 +4910,20 @@ viem@^2.17.4:
     abitype "1.0.5"
     isows "1.0.4"
     webauthn-p256 "0.0.5"
+    ws "8.17.1"
+
+viem@^2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.17.3.tgz#f15616049d8154b83e499eb5446e6d7fe6312626"
+  integrity sha512-FY/1uBQWfko4Esy8mU1RamvL64TLy91LZwFyQJ20E6AI3vTTEOctWfSn0pkMKa3okq4Gxs5dJE7q1hmWOQ7xcw==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.0"
+    "@noble/curves" "1.4.0"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.3.0"
+    abitype "1.0.5"
+    isows "1.0.4"
     ws "8.17.1"
 
 walker@^1.0.8:


### PR DESCRIPTION
This PR updates the `verifySignature` function to use a viem client so that it can also verify smart contract wallet signatures.

Open questions:
1. Should the public client be connected to mainnet or optimism? I would assume mainnet because optimism would require updating the domain's chain id to be `10`?
2. The public client should use a dedicated RPC, can I add an env var like `OP_ALCHEMY_SECRET` e.g. `MAINNET_ALCHEMY_SECRET`?