### PR TITLE
chore: fix timestamp validation logging

### DIFF
--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -133,13 +133,15 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
     throw new ValidationError('TOO_MANY_NAMES');
   }
 
-  if (req.timestamp > currentTimestamp() + TIMESTAMP_TOLERANCE) {
-    log.error(`Timestamp ${req.timestamp} was > ${TIMESTAMP_TOLERANCE}`);
+  const maxAcceptableTimestamp = currentTimestamp() + TIMESTAMP_TOLERANCE;
+  if (req.timestamp > maxAcceptableTimestamp) {
+    log.error(`Timestamp ${req.timestamp} was > ${maxAcceptableTimestamp}`);
     throw new ValidationError('INVALID_TIMESTAMP');
   }
 
-  if (req.timestamp < currentTimestamp() - TIMESTAMP_TOLERANCE) {
-    log.error(`Timestamp ${req.timestamp} was < ${TIMESTAMP_TOLERANCE}`);
+  const minAcceptableTimestamp = currentTimestamp() - TIMESTAMP_TOLERANCE;
+  if (req.timestamp < minAcceptableTimestamp) {
+    log.error(`Timestamp ${req.timestamp} was < ${minAcceptableTimestamp}`);
     throw new ValidationError('INVALID_TIMESTAMP');
   }
 


### PR DESCRIPTION
Log the actual computed timestamp threshold rather than just logging the amount the current time was widened by. 