### PR TITLE
Update release script to use remote deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,16 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: fname-registry-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
-    uses: ./.github/workflows/perform-action.yml
+    uses: warpcast/remote-exec
     with:
-      action: deploy
-    secrets: inherit
-    concurrency:
-      group: deploy
-      cancel-in-progress: false
+      git-repo: ${{ github.repository }}
+      git-ref: ${{ github.sha }}
+      command: make deploy
+      project: fname-registry
+      ssh-key: ${{ secrets.STACK_DEPLOY_SSH_PRIVATE_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -1,71 +1,58 @@
 # Lists `make <cmd>` shortcuts which are easier to type than the full command.
 
-ifeq ($(CI), true)
-	EARTHLY_INTERACTIVE_ARGS := --ci
-	CMD_TYPE := cmd
-	CI_ARGS := --CI=true
-else
-	EARTHLY_INTERACTIVE_ARGS := --interactive
-	CMD_TYPE := interactive-cmd
-	CI_ARGS :=
-endif
+docker_registry := 526236635984.dkr.ecr.us-east-1.amazonaws.com/farcasterxyz/fname-registry
+commit_ref := $(shell git rev-parse HEAD)
+docker_image := $(docker_registry):$(commit_ref)
 
 ifeq ($(release),)
-	release=
-	RELEASE_ARGS := --release=$(shell node -e "console.log(new Date().toISOString().replace(/\:/g,'-').replace(/\./g,'-'))")
+	RELEASE_ARGS := --release=$(shell date +"%Y-%m-%dT%H-%M-%Sz")-$(shell git rev-parse --short HEAD)
 else
 	RELEASE_ARGS :=
 endif
 
-REF_ARGS := --fname_registry_commit_ref=$(shell git rev-parse HEAD)
-
-ifdef pod
-	POD_ARGS := pod:$(pod)
-else
-	POD_ARGS :=
-endif
-
-CMD_PREFIX := earthly --env-file-path /dev/null --max-remote-cache
-
-# Builds (but doesn't publish) the current Docker image specified by fname_registry_commit_ref in the Earthfile and outputs it locally.
+# Builds (but doesn't publish) the current Docker image
 .PHONY: build
 build:
-	$(CMD_PREFIX) $(EARTHLY_INTERACTIVE_ARGS) +fname-registry-prod $(REF_ARGS) $(CI_ARGS)
+	docker build --tag $(docker_image) -f Dockerfile .
 
-# Builds and publishes the current Docker image specified by fname_registry_commit_ref in the Earthfile
+# Builds and publishes the current Docker image
 .PHONY: publish
 publish:
-	$(CMD_PREFIX) --push +fname-registry-prod $(REF_ARGS)
+	docker build --tag $(docker_image) -f Dockerfile --push .
+
+.PHONY: assert-published
+assert-published:
+	docker manifest inspect $(docker_image)
 
 # Shows what infrastructure changes will be applied on the next deploy, if any.
 .PHONY: plan
 plan:
-	$(CMD_PREFIX) --ci --no-output +cmd $(REF_ARGS) --CI=true --args="plan $(RELEASE_ARGS) $(POD_ARGS)"
+	STACK_DOCKER_IMAGE=$(docker_image) stack plan --yes $(RELEASE_ARGS) $(POD_ARGS)
 
 # Applies any infrastructure changes without carrying out the rest of the deploy
 # process (note: this could still result in a "deploy" if updating ASGs).
 .PHONY: apply
-apply: publish
-	$(CMD_PREFIX) $(EARTHLY_INTERACTIVE_ARGS) --no-output +$(CMD_TYPE) $(REF_ARGS) $(CI_ARGS) --args="deploy --apply-only --yes $(RELEASE_ARGS) $(POD_ARGS)"
+apply: assert-published
+	STACK_DOCKER_IMAGE=$(docker_image) stack deploy --apply-only --yes $(RELEASE_ARGS) $(POD_ARGS)
 
 # Applies any infrastructure changes (if any) and carries out a deploy.
 .PHONY: deploy
-deploy: publish
-	$(CMD_PREFIX) $(EARTHLY_INTERACTIVE_ARGS) --no-output +$(CMD_TYPE) $(REF_ARGS) $(CI_ARGS) --args="deploy --yes $(RELEASE_ARGS) $(POD_ARGS)"
+deploy: assert-published
+	STACK_DOCKER_IMAGE=$(docker_image) stack deploy --yes $(RELEASE_ARGS) $(POD_ARGS)
 
 # DANGEROUS. Deletes infrastructure.
 .PHONY: destroy
 destroy:
-	$(CMD_PREFIX) $(EARTHLY_INTERACTIVE_ARGS) --no-output +$(CMD_TYPE) $(REF_ARGS) $(CI_ARGS) --args="destroy --yes $(POD_ARGS)"
+	STACK_DOCKER_IMAGE=$(docker_image) stack destroy $(POD_ARGS)
 
 # Validates configuration files, reporting any issues.
-.PHONY: lint
-lintit:
-	$(CMD_PREFIX) $(EARTHLY_INTERACTIVE_ARGS) --no-output +$(CMD_TYPE) $(REF_ARGS) $(CI_ARGS) --args="lint"
+.PHONY: lint-stack
+lint-stack:
+	STACK_DOCKER_IMAGE=$(docker_image) stack lint
 
 # Open an SSH console to the specified pod.
 #
 # e.g. `make ssh pod=mypod`
 .PHONY: ssh
 ssh:
-	$(CMD_PREFIX) --no-output +$(CMD_TYPE) $(REF_ARGS) --args="console $(POD_ARGS)"
+	STACK_DOCKER_IMAGE=$(docker_image) stack console $(POD_ARGS)


### PR DESCRIPTION
This allows us to remove a bunch of secrets and ultimately make the deploy process more secure.
