### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/src/reserved.ts
+++ b/src/reserved.ts
@@ -93,7 +93,7 @@ const RESERVED_USERNAMES = new Set([
   'tesla',
   'tezos',
   'travel',
-  'twitter',
+  'x',
   'uber',
   'un',
   'uniswap',


### PR DESCRIPTION
Replaced the outdated Twitter URL (twitter) with the updated x.com format (x) to align with the platform's rebranding.