### PR TITLE
Fetch ENS data from hubs

### DIFF
--- a/src/ccip-signature.ts
+++ b/src/ccip-signature.ts
@@ -10,22 +10,22 @@ const ccip_domain = {
 
 const types = {
   DataProof: [
-    { name: 'data', type: 'bytes' },
-    { name: 'timestamp', type: 'uint256' },
-    { name: 'owner', type: 'address' },
+    { name: 'request', type: 'bytes32' },
+    { name: 'response', type: 'bytes' },
+    { name: 'validUntil', type: 'uint256' },
   ],
 };
 
 export async function generateCCIPSignature(
-  functionResult: `0x${string}`,
-  timestamp: number,
-  owner: string,
+  request: `0x${string}`,
+  response: `0x${string}`,
+  validUntil: number,
   signer: ethers.Signer
 ) {
   const dataProof = {
-    data: functionResult,
-    timestamp,
-    owner: owner,
+    request,
+    response,
+    validUntil,
   };
 
   const signature = await signer.signTypedData(ccip_domain, types, dataProof);
@@ -33,16 +33,16 @@ export async function generateCCIPSignature(
 }
 
 export function verifyCCIPSignature(
-  functionResult: `0x${string}`,
-  timestamp: number,
-  owner: `0x${string}`,
+  request: `0x${string}`,
+  response: `0x${string}`,
+  validUntil: number,
   signature: string,
   signerAddress: string
 ) {
   const dataProof = {
-    data: functionResult,
-    timestamp,
-    owner: owner,
+    request,
+    response,
+    validUntil,
   };
   const signer = ethers.verifyTypedData(ccip_domain, types, dataProof, signature);
   return signer.toLowerCase() === signerAddress.toLowerCase();

--- a/src/ccip-signature.ts
+++ b/src/ccip-signature.ts
@@ -1,0 +1,49 @@
+import { ethers } from 'ethers';
+import { CCIP_ADDRESS } from './env.js';
+
+const ccip_domain = {
+  name: 'Farcaster name verification',
+  version: '1',
+  chainId: 1,
+  verifyingContract: CCIP_ADDRESS,
+};
+
+const types = {
+  DataProof: [
+    { name: 'data', type: 'bytes' },
+    { name: 'timestamp', type: 'uint256' },
+    { name: 'owner', type: 'address' },
+  ],
+};
+
+export async function generateCCIPSignature(
+  functionResult: `0x${string}`,
+  timestamp: number,
+  owner: string,
+  signer: ethers.Signer
+) {
+  const dataProof = {
+    data: functionResult,
+    timestamp,
+    owner: owner,
+  };
+
+  const signature = await signer.signTypedData(ccip_domain, types, dataProof);
+  return signature;
+}
+
+export function verifyCCIPSignature(
+  functionResult: `0x${string}`,
+  timestamp: number,
+  owner: `0x${string}`,
+  signature: string,
+  signerAddress: string
+) {
+  const dataProof = {
+    data: functionResult,
+    timestamp,
+    owner: owner,
+  };
+  const signer = ethers.verifyTypedData(ccip_domain, types, dataProof, signature);
+  return signer.toLowerCase() === signerAddress.toLowerCase();
+}

--- a/src/ccip-signature.ts
+++ b/src/ccip-signature.ts
@@ -11,20 +11,20 @@ const ccip_domain = {
 const types = {
   DataProof: [
     { name: 'request', type: 'bytes32' },
-    { name: 'response', type: 'bytes' },
+    { name: 'result', type: 'bytes32' },
     { name: 'validUntil', type: 'uint256' },
   ],
 };
 
 export async function generateCCIPSignature(
   request: `0x${string}`,
-  response: `0x${string}`,
+  result: `0x${string}`,
   validUntil: number,
   signer: ethers.Signer
 ) {
   const dataProof = {
     request,
-    response,
+    result,
     validUntil,
   };
 
@@ -34,14 +34,14 @@ export async function generateCCIPSignature(
 
 export function verifyCCIPSignature(
   request: `0x${string}`,
-  response: `0x${string}`,
+  result: `0x${string}`,
   validUntil: number,
   signature: string,
   signerAddress: string
 ) {
   const dataProof = {
     request,
-    response,
+    result,
     validUntil,
   };
   const signer = ethers.verifyTypedData(ccip_domain, types, dataProof, signature);

--- a/src/env.ts
+++ b/src/env.ts
@@ -23,3 +23,5 @@ if (ENVIRONMENT === 'prod' && CCIP_ADDRESS === '') {
 }
 
 export const ID_REGISTRY_ADDRESS = process.env['ID_REGISTRY_ADDRESS'] || '0x00000000fc6c5f01fc30151999387bb99a9f489b';
+
+export const HUB_GRPC_URL = new URL(process.env['HUB_GRPC_URL'] || 'http://localhost:2281');

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -44,8 +44,8 @@ export async function getRecordFromHub(
 
   return {
     plain: result,
-    // This is what the output of ENS resolve() expects, and will ultimately be returned to the client
-    encoded: encodeFunctionResult({
+    // This is what the response of ENS resolve() looks like, and will ultimately be returned to the client
+    response: encodeFunctionResult({
       abi: BASE_RESOLVER_ABI,
       functionName,
       result,

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,0 +1,139 @@
+import { encodeFunctionResult, zeroAddress } from 'viem';
+
+import { log } from './log.js';
+import { HUB_GRPC_URL } from './env.js';
+import { decodeEnsRequest, BASE_RESOLVER_ABI } from './util.js';
+
+// ENS text record keys to support
+const supportedKeys = ['avatar', 'description', 'url'] as const;
+type SupportedKey = (typeof supportedKeys)[number];
+
+/**
+ *
+ * @param fid
+ * @param param1
+ * @returns An object with the raw and encoded ENS record
+ */
+export async function getRecordFromHub(
+  fid: number,
+  { functionName, args }: NonNullable<ReturnType<typeof decodeEnsRequest>>
+) {
+  let result: string = '';
+
+  if (functionName === 'addr') {
+    const coinType = args[1] ?? 60n; // 60 is ETH (SLIP-0044)
+
+    // Farcaster doesn't store different addresses per chain, so we'll assume all addresses are valid on all EVM chains
+    // This checks if a request is for ETH or an L2 (ENSIP-11)
+    if (coinType !== 60n && coinType < 0x80000000) {
+      log.warn(`Unsupported coin type ${coinType}`);
+      result = zeroAddress;
+    } else {
+      result = await getEthAddressByFid(fid);
+    }
+  }
+
+  if (functionName === 'text') {
+    const key = args[1] as SupportedKey;
+
+    // Only handle keys that hubs might have
+    if (supportedKeys.includes(key)) {
+      result = await getUserDataByFid(fid, key);
+    }
+  }
+
+  return {
+    plain: result,
+    // This is what the output of ENS resolve() expects, and will ultimately be returned to the client
+    encoded: encodeFunctionResult({
+      abi: BASE_RESOLVER_ABI,
+      functionName,
+      result,
+    }),
+  };
+}
+
+// TODO: figure out if all the types below can be imported from other Farcaster packages
+// Or get GRPC working and connect to the client from @farcaster/hub-nodejs for strong types
+type Protocol = 'PROTOCOL_ETHEREUM' | 'PROTOCOL_SOLANA';
+
+type HttpVerificationsResponse = {
+  messages: Array<{
+    data: {
+      type: string;
+      fid: number;
+      timestamp: number;
+      network: string;
+      verificationAddAddressBody: {
+        address: string;
+        claimSignature: string;
+        blockHash: string;
+        verificationType: number;
+        chainId: number;
+        protocol: Protocol;
+        ethSignature: string;
+      };
+      verificationAddEthAddressBody: {
+        address: string;
+        claimSignature: string;
+        blockHash: string;
+        verificationType: number;
+        chainId: number;
+        protocol: Protocol;
+        ethSignature: string;
+      };
+    };
+    hash: string;
+    hashScheme: string;
+    signature: string;
+    signatureScheme: string;
+    signer: string;
+  }>;
+  nextPageToken: string;
+};
+
+async function getEthAddressByFid(fid: number) {
+  const res = await fetch(HUB_GRPC_URL.origin + '/v1/verificationsByFid?fid=' + fid);
+  const verifications = (await res.json()) as HttpVerificationsResponse;
+
+  const ethVerifications = verifications.messages.filter(
+    (m) => m.data?.verificationAddAddressBody?.protocol === 'PROTOCOL_ETHEREUM'
+  );
+  const ethAddress = ethVerifications[0]?.data?.verificationAddAddressBody?.address;
+  return ethAddress ?? zeroAddress;
+}
+
+type HttpUserDataResponse = {
+  messages: Array<{
+    data: {
+      type: string;
+      fid: number;
+      timestamp: number;
+      network: string;
+      userDataBody: {
+        type: string;
+        value: string;
+      };
+    };
+    hash: string;
+    hashScheme: string;
+    signature: string;
+    signatureScheme: string;
+    signer: string;
+  }>;
+  nextPageToken: string;
+};
+
+const ensTextKeyToHubType: Record<SupportedKey, string> = {
+  avatar: 'USER_DATA_TYPE_PFP',
+  description: 'USER_DATA_TYPE_BIO',
+  url: 'USER_DATA_TYPE_URL',
+};
+
+async function getUserDataByFid(fid: number, key: SupportedKey) {
+  const hubType = ensTextKeyToHubType[key];
+  const res = await fetch(HUB_GRPC_URL.origin + '/v1/userDataByFid?fid=' + fid);
+  const json = (await res.json()) as HttpUserDataResponse;
+  const message = json.messages.find((m) => m.data.userDataBody.type === hubType);
+  return message?.data.userDataBody.value ?? '';
+}

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,6 +1,5 @@
 import { encodeFunctionResult, zeroAddress } from 'viem';
 
-import { log } from './log.js';
 import { HUB_GRPC_URL } from './env.js';
 import { decodeEnsRequest, BASE_RESOLVER_ABI } from './util.js';
 
@@ -25,11 +24,10 @@ export async function getRecordFromHub(
 
     // Farcaster doesn't store different addresses per chain, so we'll assume all addresses are valid on all EVM chains
     // This checks if a request is for ETH or an L2 (ENSIP-11)
-    if (coinType !== 60n && coinType < 0x80000000) {
-      log.warn(`Unsupported coin type ${coinType}`);
-      result = zeroAddress;
-    } else {
+    if (coinType === 60n || coinType > 0x80000000) {
       result = await getEthAddressByFid(fid);
+    } else {
+      result = zeroAddress;
     }
   }
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionResult, zeroAddress } from 'viem';
+import { AbiItem, encodeFunctionResult, zeroAddress } from 'viem';
 
 import { HUB_GRPC_URL } from './env.js';
 import { decodeEnsRequest, BASE_RESOLVER_ABI } from './util.js';
@@ -40,11 +40,16 @@ export async function getRecordFromHub(
     }
   }
 
+  // Find the correct ABI item for each function, otherwise `addr(node, coinType)` gets incorrectly encoded as `addr(node)`
+  const abi: AbiItem | undefined = BASE_RESOLVER_ABI.find(
+    (abi) => abi.name === functionName && abi.inputs.length === args.length
+  );
+
   return {
     plain: result,
     // This is what the response of ENS resolve() looks like, and will ultimately be returned to the client
     response: encodeFunctionResult({
-      abi: BASE_RESOLVER_ABI,
+      abi: [abi],
       functionName,
       result,
     }),

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import * as process from 'process';
 import { createPublicClient, fallback, http } from 'viem';
 import { optimism } from 'viem/chains';
-import { CCIP_ADDRESS, OP_ALCHEMY_SECRET, WARPCAST_ADDRESS } from './env.js';
+import { OP_ALCHEMY_SECRET, WARPCAST_ADDRESS } from './env.js';
 
 export const signer = ethers.Wallet.fromPhrase(
   process.env.MNEMONIC || 'test test test test test test test test test test test junk'
@@ -26,12 +26,7 @@ const hub_domain = {
   // TODO: When changing, remember to also update on the backend!
   verifyingContract: '0xe3be01d99baa8db9905b33a3ca391238234b79d1', // name registry contract, will be the farcaster ENS CCIP contract later
 } as const;
-const ccip_domain = {
-  name: 'Farcaster name verification',
-  version: '1',
-  chainId: 1,
-  verifyingContract: CCIP_ADDRESS,
-};
+
 const types = {
   UserNameProof: [
     { name: 'name', type: 'string' },
@@ -47,15 +42,6 @@ export async function generateSignature(userName: string, timestamp: number, own
     owner: owner,
   };
   return Buffer.from((await signer.signTypedData(hub_domain, types, userNameProof)).replace(/^0x/, ''), 'hex');
-}
-
-export async function generateCCIPSignature(userName: string, timestamp: number, owner: string, signer: ethers.Signer) {
-  const userNameProof = {
-    name: userName,
-    timestamp,
-    owner: owner,
-  };
-  return Buffer.from((await signer.signTypedData(ccip_domain, types, userNameProof)).replace(/^0x/, ''), 'hex');
 }
 
 export async function verifySignature(
@@ -87,20 +73,4 @@ export async function verifySignature(
   });
 
   return verifyResult;
-}
-
-export function verifyCCIPSignature(
-  userName: string,
-  timestamp: number,
-  owner: string,
-  signature: string,
-  signerAddress: string
-) {
-  const userNameProof = {
-    name: userName,
-    timestamp,
-    owner: owner,
-  };
-  const signer = ethers.verifyTypedData(ccip_domain, types, userNameProof, signature);
-  return signer.toLowerCase() === signerAddress.toLowerCase();
 }

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -231,6 +231,7 @@ function toTransferResponse(row: Selectable<TransfersTable> | undefined) {
     to: row.to,
     user_signature: bytesToHex(row.userSignature),
     server_signature: bytesToHex(row.serverSignature),
+    user_fid: row.userFid,
   };
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,7 @@ import {
   BigNumberish,
   ZeroHash,
 } from 'ethers';
+import { decodeFunctionData, parseAbi } from 'viem';
 
 export type EventArgBasicValue = string | number | boolean;
 type EventArgValue = EventArgBasicValue | EventArgBasicValue[] | EventArgs;
@@ -107,4 +108,22 @@ export function decodeDnsName(name: string) {
     idx += len + 1;
   }
   return labels;
+}
+
+export const BASE_RESOLVER_ABI = parseAbi([
+  'function addr(bytes32) external pure returns (address)',
+  'function addr(bytes32, uint256) external pure returns (address)',
+  'function text(bytes32, string) external pure returns (string memory)',
+]);
+
+export function decodeEnsRequest(data: `0x${string}`) {
+  try {
+    return decodeFunctionData({
+      abi: BASE_RESOLVER_ABI,
+      data,
+    });
+  } catch {
+    // Handle lookups of records that we don't support like contenthash
+    return null;
+  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -111,9 +111,9 @@ export function decodeDnsName(name: string) {
 }
 
 export const BASE_RESOLVER_ABI = parseAbi([
-  'function addr(bytes32) external pure returns (address)',
-  'function addr(bytes32, uint256) external pure returns (address)',
-  'function text(bytes32, string) external pure returns (string memory)',
+  'function addr(bytes32 node) view returns (address)',
+  'function addr(bytes32 node, uint256 coinType) view returns (bytes memory)',
+  'function text(bytes32 node, string key) view returns (string memory)',
 ]);
 
 export function decodeEnsRequest(data: `0x${string}`) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -254,7 +254,6 @@ describe('app', () => {
             args: [dnsEncodedName, encodedResolveCall],
         })
       */
-      const encodedResolveCall = '0x3b3b57def92c9492f04f951f8a3b5f9bc1b8504c7950352e3641270b54ab9de19b7e3ad7';
       const encodedWildcardResolveCalldata =
         '0x9061b923000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000015057465737431096661726361737465720365746800000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57def92c9492f04f951f8a3b5f9bc1b8504c7950352e3641270b54ab9de19b7e3ad700000000000000000000000000000000000000000000000000000000';
 
@@ -275,13 +274,12 @@ describe('app', () => {
       expect(validUntil).toBeGreaterThan(now);
       // The signature is really only valid for 60 seconds, but `now` is from the start of the test running so we need some buffer
       expect(validUntil).toBeLessThan(now + 90);
-      expect(hashedRequest).toBe(keccak256(encodedResolveCall));
-      expect(verifyCCIPSignature(hashedRequest, result, validUntil, signature, signer.address)).toBe(true);
+      expect(hashedRequest).toBe(keccak256(encodedWildcardResolveCalldata));
+      expect(verifyCCIPSignature(hashedRequest, keccak256(result), validUntil, signature, signer.address)).toBe(true);
     });
 
     it('should return an empty signature for a ccip lookup of an unregistered name', async () => {
       // Calldata for alice.farcaster.eth
-      const encodedResolveCall = '0x3b3b57dee224cf2d7e9641e5b9cde025d9e3db25df5d8789bb7a5c9f4bb28b3e18c2717e';
       const encodedWildcardResolveCall =
         '0x9061b92300000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001505616c696365096661726361737465720365746800000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57dee224cf2d7e9641e5b9cde025d9e3db25df5d8789bb7a5c9f4bb28b3e18c2717e00000000000000000000000000000000000000000000000000000000';
       const response = await request(app).get(`/ccip/${CCIP_ADDRESS}/${encodedWildcardResolveCall}.json`);
@@ -290,7 +288,7 @@ describe('app', () => {
         resolveABI.outputs,
         response.body.data
       );
-      expect(hashedRequest).toBe(keccak256(encodedResolveCall));
+      expect(hashedRequest).toBe(keccak256(encodedWildcardResolveCall));
       expect(result).toBe('0x');
       expect(validUntil).toBeGreaterThan(now);
       expect(validUntil).toBeLessThan(now + 90);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,19 +3,14 @@ import { app, RESOLVE_ABI } from '../src/app.js';
 import { sql } from 'kysely';
 import { getWriteClient, migrateToLatest } from '../src/db.js';
 import { log } from '../src/log.js';
-import {
-  generateSignature,
-  signer,
-  signerAddress,
-  signerFid,
-  verifyCCIPSignature,
-  verifySignature,
-} from '../src/signature.js';
-import { bytesToHex, currentTimestamp } from '../src/util.js';
+import { generateSignature, signer, signerAddress, signerFid, verifySignature } from '../src/signature.js';
+import { verifyCCIPSignature } from '../src/ccip-signature.js';
+import { BASE_RESOLVER_ABI, bytesToHex, currentTimestamp } from '../src/util.js';
 import { createTestTransfer } from './utils.js';
-import { AbiCoder, ethers, Interface, ZeroAddress } from 'ethers';
+import { AbiCoder, ethers, Interface } from 'ethers';
 import { CCIP_ADDRESS } from '../src/env.js';
 import { jest } from '@jest/globals';
+import { encodeFunctionResult, zeroAddress } from 'viem';
 
 const db = getWriteClient();
 const anotherSigner = ethers.Wallet.createRandom();
@@ -241,34 +236,59 @@ describe('app', () => {
     const resolveABI = new Interface(RESOLVE_ABI).getFunction('resolve')!;
 
     it('should return a valid signature for a ccip lookup of a registered name', async () => {
-      // Calldata for test1.farcaster.xyz
-      const callData =
-        '0x9061b923000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000015057465737431096661726361737465720378797a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57deeea35aa5de7e8da11d1636463a57da877fa0c0c65b969f7fecb7eb6c93a20c1b00000000000000000000000000000000000000000000000000000000';
-      const response = await request(app).get(`/ccip/${CCIP_ADDRESS}/${callData}.json`);
+      /* 
+        Code used to generate the encodedWildcardResolveCalldata. Typescript doesn't like it directly in this test for some reason.
+
+        const name = 'test1.farcaster.eth';
+        const dnsEncodedName = toHex(packetToBytes(name));
+
+        const encodedResolveCall = encodeFunctionData({
+            abi: BASE_RESOLVER_ABI,
+            functionName: 'addr',
+            args: [namehash(name)],
+        });
+
+        const encodedWildcardResolveCall = encodeFunctionData({
+            abi: RESOLVE_ABI,
+            functionName: 'resolve',
+            args: [dnsEncodedName, encodedResolveCall],
+        })
+      */
+      const encodedWildcardResolveCalldata =
+        '0x9061b923000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000015057465737431096661726361737465720365746800000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57def92c9492f04f951f8a3b5f9bc1b8504c7950352e3641270b54ab9de19b7e3ad700000000000000000000000000000000000000000000000000000000';
+
+      const response = await request(app).get(`/ccip/${CCIP_ADDRESS}/${encodedWildcardResolveCalldata}.json`);
       expect(response.status).toBe(200);
-      const [username, timestamp, owner, signature] = AbiCoder.defaultAbiCoder().decode(
+      const [functionResult, timestamp, owner, signature] = AbiCoder.defaultAbiCoder().decode(
         resolveABI.outputs,
         response.body.data
       );
-      expect(username).toBe('test1');
-      expect(verifyCCIPSignature(username, timestamp, owner, signature, signer.address)).toBe(true);
+
+      const expectedFunctionResult = encodeFunctionResult({
+        abi: BASE_RESOLVER_ABI,
+        functionName: 'addr',
+        result: zeroAddress,
+      });
+
+      expect(functionResult).toBe(expectedFunctionResult);
+      expect(verifyCCIPSignature(functionResult, timestamp, owner, signature, signer.address)).toBe(true);
       // CCIP domain is different from hub domain
-      expect(await verifySignature(username, timestamp, owner, signature, signer.address)).toBe(false);
+      expect(await verifySignature(functionResult, timestamp, owner, signature, signer.address)).toBe(false);
     });
 
     it('should return an empty signature for a ccip lookup of an unregistered name', async () => {
-      // Calldata for alice.farcaster.xyz
+      // Calldata for alice.farcaster.eth
       const callData =
-        '0x9061b92300000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001505616c696365096661726361737465720378797a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57de00d4f449060ad2a07ff5ad355ae8da52281e95f6ad10fb923ae7cad9f2c43c2a00000000000000000000000000000000000000000000000000000000';
+        '0x9061b92300000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001505616c696365096661726361737465720365746800000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57dee224cf2d7e9641e5b9cde025d9e3db25df5d8789bb7a5c9f4bb28b3e18c2717e00000000000000000000000000000000000000000000000000000000';
       const response = await request(app).get(`/ccip/${CCIP_ADDRESS}/${callData}.json`);
       expect(response.status).toBe(200);
-      const [username, timestamp, owner, signature] = AbiCoder.defaultAbiCoder().decode(
+      const [functionResult, timestamp, owner, signature] = AbiCoder.defaultAbiCoder().decode(
         resolveABI.outputs,
         response.body.data
       );
-      expect(username).toBe('');
+      expect(functionResult).toBe('0x');
       expect(timestamp.toString()).toEqual('0');
-      expect(owner).toBe(ZeroAddress);
+      expect(owner).toBe(zeroAddress);
       expect(signature).toBe('0x');
     });
   });


### PR DESCRIPTION
Before: CCIP Read requests only handled ETH address lookup and would return the custody address of the Farcaster account that controls the username.

With these changes: The ETH address returned to ENS is a verification rather than the custody address, and the `description` and `avatar` ENS text records pull user data from hubs.

Notes:
- Adds a hub URL as a dependency
- Matches the contract changes in https://github.com/farcasterxyz/contracts/pull/464
- Expects that Farcaster verifications are valid across all EVM L2s

This is what a profile looks like on app.ens.domains (I own farcaster.eth on Sepolia, but it won't work when you look because I'm using a temporary ngrok URL as the gateway)

<img width="797" alt="image" src="https://github.com/user-attachments/assets/193beedd-9406-4446-b842-6afd466d290f" />
