### PR TITLE
return latest transfer id from /current even if no name is provided

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ server.add(RESOLVE_ABI, [
     type: 'resolve',
     func: async ([name, _data], _req) => {
       const fname = decodeDnsName(name)[0];
-      const transfer = await getLatestTransfer(fname, read);
+      const transfer = await getLatestTransfer(read, fname);
       if (!transfer || transfer.to === 0) {
         // If no transfer or the name was unregistered, return empty values
         return ['', 0, ZeroAddress, '0x'];
@@ -87,11 +87,11 @@ app.get('/transfers/current', async (req, res) => {
     } else if (req.query.name) {
       name = req.query.name.toString();
     }
-    if (!name || name === '') {
-      res.status(404).send({ error: 'Could not resolve current name' }).end();
+    if (name === '') {
+      res.status(404).send({ error: 'Could not resolve empty name' }).end();
       return;
     }
-    const transfer = await getLatestTransfer(name, read);
+    const transfer = await getLatestTransfer(read, name);
     if (!transfer || transfer.to === 0) {
       res.status(404).send({ error: 'No transfer found' }).end();
       return;

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -127,7 +127,7 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
     throw new ValidationError('INVALID_USERNAME');
   }
 
-  const existingTransfer = await getLatestTransfer(req.username, db);
+  const existingTransfer = await getLatestTransfer(db, req.username);
 
   const existingName = await getCurrentUsername(req.to, db);
   if (existingName) {
@@ -181,16 +181,10 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
   }
 }
 
-export async function getLatestTransfer(name: string, db: Kysely<Database>) {
-  return toTransferResponse(
-    await db
-      .selectFrom('transfers')
-      .selectAll()
-      .where('username', '=', name)
-      .orderBy('timestamp', 'desc')
-      .limit(1)
-      .executeTakeFirst()
-  );
+export async function getLatestTransfer(db: Kysely<Database>, name?: string) {
+  const baseQuery = db.selectFrom('transfers').selectAll();
+  const query = name ? baseQuery.where('username', '=', name) : baseQuery;
+  return toTransferResponse(await query.orderBy('timestamp', 'desc').limit(1).executeTakeFirst());
 }
 
 export async function getCurrentUsername(fid: number, db: Kysely<Database>) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -106,10 +106,6 @@ describe('app', () => {
       response = await request(app).get('/transfers/current?fid=3');
       expect(response.status).toBe(404);
     });
-    test('returns error if no name or fid provided', async () => {
-      const response = await request(app).get('/transfers/current');
-      expect(response.status).toBe(404);
-    });
     test('returns latest transfer for fid', async () => {
       await createTestTransfer(db, { username: 'test-current', from: 0, to: 3, timestamp: now + 3 });
       const response = await request(app).get('/transfers/current?fid=3');
@@ -121,6 +117,12 @@ describe('app', () => {
       const response = await request(app).get('/transfers/current?name=test3');
       expect(response.status).toBe(200);
       expect(response.body.transfer).toMatchObject({ username: 'test3', from: 0, to: 10, timestamp: now + 3 });
+    });
+    test('returns latest transfer for no name', async () => {
+      await createTestTransfer(db, { username: 'test-latest', from: 0, to: 11, timestamp: now + 10 });
+      const response = await request(app).get('/transfers/current');
+      expect(response.status).toBe(200);
+      expect(response.body.transfer).toMatchObject({ username: 'test-latest', from: 0, to: 11, timestamp: now + 10 });
     });
   });
 

--- a/tests/transfers.test.ts
+++ b/tests/transfers.test.ts
@@ -263,7 +263,16 @@ describe('transfers', () => {
 
   describe('getLatestTransfer', () => {
     test('should return the latest transfer', async () => {
-      const latest = await getLatestTransfer('test123', db);
+      const latest = await getLatestTransfer(db, 'test123');
+      expect(latest).toBeDefined();
+      expect(latest!.username).toBe('test123');
+      expect(latest!.from).toBe(1);
+      expect(latest!.to).toBe(2);
+      expect(latest!.user_signature).toBeDefined();
+      expect(latest!.server_signature).toBeDefined();
+    });
+    test('returns latest transfer overall if no name is provided', async () => {
+      const latest = await getLatestTransfer(db);
       expect(latest).toBeDefined();
       expect(latest!.username).toBe('test123');
       expect(latest!.from).toBe(1);
@@ -272,7 +281,7 @@ describe('transfers', () => {
       expect(latest!.server_signature).toBeDefined();
     });
     test('returns undefined if no transfer', async () => {
-      const latest = await getLatestTransfer('nonexistent', db);
+      const latest = await getLatestTransfer(db, 'nonexistent');
       expect(latest).toBeUndefined();
     });
   });


### PR DESCRIPTION
We need this functionality to resume fname transfer ingest from the latest for snapchain. 