### PR TITLE
fix handling of undefined/empty usernames for the /transfers/current endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,21 +77,26 @@ app.get('/transfers', async (req, res) => {
 
 app.get('/transfers/current', async (req, res) => {
   try {
-    let name: string | undefined;
+    let transfer;
     if (req.query.fid) {
       if (Number.isNaN(Number(req.query.fid))) {
         res.status(400).send({ error: 'FID is not a number' }).end();
         return;
       }
-      name = await getCurrentUsername(parseInt(req.query.fid.toString()), read);
+      const name = await getCurrentUsername(parseInt(req.query.fid.toString()), read);
+      if (!name || name === '') {
+        res.status(404).send({ error: 'Could not resolve current name' }).end();
+      }
+      transfer = await getLatestTransfer(read, name);
     } else if (req.query.name) {
-      name = req.query.name.toString();
+      const name = req.query.name.toString();
+      if (!name || name === '') {
+        res.status(404).send({ error: 'Could not resolve current name' }).end();
+      }
+      transfer = await getLatestTransfer(read, name);
+    } else {
+      transfer = await getLatestTransfer(read);
     }
-    if (name === '') {
-      res.status(404).send({ error: 'Could not resolve empty name' }).end();
-      return;
-    }
-    const transfer = await getLatestTransfer(read, name);
     if (!transfer || transfer.to === 0) {
       res.status(404).send({ error: 'No transfer found' }).end();
       return;

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,12 +86,14 @@ app.get('/transfers/current', async (req, res) => {
       const name = await getCurrentUsername(parseInt(req.query.fid.toString()), read);
       if (!name || name === '') {
         res.status(404).send({ error: 'Could not resolve current name' }).end();
+        return;
       }
       transfer = await getLatestTransfer(read, name);
     } else if (req.query.name) {
       const name = req.query.name.toString();
       if (!name || name === '') {
         res.status(404).send({ error: 'Could not resolve current name' }).end();
+        return;
       }
       transfer = await getLatestTransfer(read, name);
     } else {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,6 +27,14 @@ beforeAll(async () => {
 describe('app', () => {
   const now = currentTimestamp();
 
+  const expectErrorWithText = (response: request.Response, includesText: string) => {
+    if (response.error === false) {
+      throw new Error('Expected error in response');
+    } else {
+      expect(response.error.text).toContain(includesText);
+    }
+  };
+
   beforeAll(async () => {
     await sql`TRUNCATE TABLE transfers RESTART IDENTITY`.execute(db);
     await createTestTransfer(db, { username: 'test1', to: 1, timestamp: now });
@@ -101,6 +109,7 @@ describe('app', () => {
     test('returns error for unknown fid', async () => {
       let response = await request(app).get('/transfers/current?fid=129837123');
       expect(response.status).toBe(404);
+      expectErrorWithText(response, 'Could not resolve current name');
 
       // Name was burned
       response = await request(app).get('/transfers/current?fid=3');


### PR DESCRIPTION
Restore the check for an `undefined` username if a username or fid is explicitly specified. We rely on this logic in the backend for the onboarding flow. 