### PR TITLE
fix: Ensure we check for the owner when transferring a name that was previously transferred

### DIFF
--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -158,6 +158,12 @@ export async function validateTransfer(req: TransferRequest, db: Kysely<Database
     throw new ValidationError('INVALID_TIMESTAMP');
   }
 
+  // If the username is owned by someone, we need to ensure that only the owner can transfer it
+  if (existingTransfer && existingTransfer.to !== 0 && existingTransfer.to !== req.from) {
+    log.error(`Trying to transfer username ${req.username} from ${req.from} but it is owned by ${existingTransfer.to}`);
+    throw new ValidationError('USERNAME_TAKEN');
+  }
+
   if (req.from === 0) {
     // Mint
     if (existingTransfer && existingTransfer.to !== 0) {

--- a/tests/transfers.test.ts
+++ b/tests/transfers.test.ts
@@ -67,6 +67,16 @@ describe('transfers', () => {
       );
     });
 
+    test('cannot transfer twice', async () => {
+      await createTestTransfer(db, { username: 'test10', from: 0, to: 10, timestamp: currentTimestamp() + 1 });
+      await createTestTransfer(db, { username: 'test10', from: 10, to: 11, timestamp: currentTimestamp() + 2 });
+
+      // 10 Cannot transfer again
+      await expect(
+        createTestTransfer(db, { username: 'test10', from: 10, to: 0, timestamp: currentTimestamp() + 3 })
+      ).rejects.toThrow('USERNAME_TAKEN');
+    });
+
     test('cannot register an invalid name', async () => {
       await expect(
         createTestTransfer(db, { username: 'namethatislongerthan16chars', from: 0, to: 10 })


### PR DESCRIPTION
In some cases like `getpara` we were allowing the previous owner to transfer the name twice. 